### PR TITLE
Read from input.txt by default, but provide --stdin flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,20 @@ Ensure you have the Java 8 SDK and Maven installed.
 The easiest way to run the application is to invoke Maven and create a packaged Jar file. This will also run all the unit tests as part of the build:
 
     $ mvn package
-    $ java -classpath target/radio-towers-1.0-SNAPSHOT.jar info.lindblad.radio.App < input.txt
+    $ java -classpath target/radio-towers-1.0-SNAPSHOT.jar info.lindblad.radio.App
 
 Example output:
 
     2/3
     4 5
 
+By default the application attempts to read the island configuration from a file named `input.txt` in the current directory.
+
 It is also possible to visualise the given island configuration using the `--visualise` flag:
+
+    $ java -classpath target/radio-towers-1.0-SNAPSHOT.jar info.lindblad.radio.App --visualise
+
+Example output:
 
 ```
 *   *   *   *   x   x   x   x   x   x
@@ -52,8 +58,45 @@ R1  *   *   *   x   x   x   x   x   x
 4 5
 ```
 
+If you want to read from standard input instead of the default `input.txt`, use the `--stdin` flag:
+
+    $ java -classpath target/radio-towers-1.0-SNAPSHOT.jar info.lindblad.radio.App --stdin < other-case.txt
+
+Example output:
+
+```
+x   x   x   x   x   x   x   x   x   x   x   *   *   *   x   x   x   x   x   x   x   x   x   x   x
+x   x   x   x   x   x   x   x   x   x   x   *   T3  *   x   x   x   x   x   x   x   x   x   x   x
+x   x   x   x   x   x   x   x   x   x   x   *   *   *   x   x   x   x   x   x   x   x   x   x   x
+x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x
+x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x
+x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x
+x   x   x   x   x   x   x   x   x   x   x   x   R4  x   x   x   x   x   x   x   x   x   x   x   x
+x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x
+x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x
+x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x
+x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x
+*   *   *   x   x   x   x   x   x   x   x   *   *   *   x   x   x   x   x   x   x   x   *   *   *
+*   T4  *   x   x   x   R2  x   x   x   x   *   T1  *   x   x   x   x   R3  x   x   x   *   T5  *
+*   *   *   x   x   x   x   x   x   x   x   *   *   *   x   x   x   x   x   x   x   x   *   *   *
+x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x
+x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x
+x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x
+x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x
+x   x   x   x   x   x   x   x   x   x   x   x   R1  x   x   x   x   x   x   x   x   x   x   x   x
+x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x
+x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x
+x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x   x
+x   x   x   x   x   x   x   x   x   x   x   *   *   *   x   x   x   x   x   x   x   x   x   x   x
+x   x   x   x   x   x   x   x   x   x   x   *   T2  *   x   x   x   x   x   x   x   x   x   x   x
+x   x   x   x   x   x   x   x   x   x   x   *   *   *   x   x   x   x   x   x   x   x   x   x   x
+
+0/4
+1 6
+```
+
 ### Run the tests separately
 
 Run the tests using Maven:
 
-    $ mvn package
+    $ mvn test

--- a/src/main/java/info/lindblad/radio/App.java
+++ b/src/main/java/info/lindblad/radio/App.java
@@ -9,8 +9,7 @@ import info.lindblad.radio.util.InputParser;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 
 public class App
@@ -19,15 +18,28 @@ public class App
     public static void main(String[] args)
     {
         /*
-          Attempt to parse input and construct an island.
+          Convert provided command line flags to a set.
          */
-        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
-        Optional<Island> islandOptional = InputParser.parse(br);
+        HashSet<String> optionFlags = new HashSet<>(Arrays.asList(args));
+
+        /*
+          Attempt to parse standard input and construct an island if the --stdin flag is set, otherwise
+          we read from a file called input.txt
+         */
+        Island island;
+        if (optionFlags.contains("--stdin")) {
+            BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+            island = InputParser.parse(br).orElseThrow(() -> new RuntimeException("Could not parse input and construct an island. Exiting."));
+        } else {
+            island = InputParser.islandFromFile(InputParser.DEFAULT_INPUT_FILENAME);
+        }
+
+        Optional<Island> islandOptional= Optional.ofNullable(island);
 
         if (islandOptional.isPresent()) {
-            Island island = islandOptional.get();
+            island = islandOptional.get();
 
-            if (args.length == 1 && args[0].equals("--visualise")) {
+            if (optionFlags.contains("--visualise")) {
                 System.out.println(island.toString(new Coverage(island)));
             }
 
@@ -47,7 +59,7 @@ public class App
                 System.out.println(String.format("%d %d", change.getKey().getId(), change.getValue()));
             }
         } else {
-            System.err.println("Could not parse input and construct an island. Exiting.");
+            System.err.println("No island provided. Exiting.");
             System.exit(1);
         }
     }

--- a/src/main/java/info/lindblad/radio/util/InputParser.java
+++ b/src/main/java/info/lindblad/radio/util/InputParser.java
@@ -21,6 +21,8 @@ import java.util.stream.Stream;
 
 public class InputParser {
 
+    public static final String DEFAULT_INPUT_FILENAME = "input.txt";
+
     private static final int ISLAND_DIMENSIONS_PARAMETER_SIZE = 2;
     private static final int TRANSMITTER_TOWER_PARAMETER_SIZE = 4;
     private static final int RECEIVER_TOWER_PARAMETER_SIZE = 3;
@@ -31,7 +33,7 @@ public class InputParser {
      * @param inputStream The InputStream
      * @return An Optional<Island> whose value depends on successful parsing
      */
-    public static Optional<Island> parse(Stream<String> inputStream) {
+    private static Optional<Island> parse(Stream<String> inputStream) {
         List<List<Integer>> input = inputStream
                 .map(InputParser::extractIntegerValues).collect(Collectors.toList());
 
@@ -105,6 +107,22 @@ public class InputParser {
     }
 
     /**
+     * Read a file from the file system
+     *
+     * @param filename The filename of the file
+     * @return An optional BufferedReader
+     */
+    private static Optional<BufferedReader> readFileFromFileSystem(String filename) {
+        try {
+            FileReader fileReader = new FileReader(filename);
+            return Optional.of(new BufferedReader(fileReader));
+        } catch (FileNotFoundException exception) {
+            System.err.println(String.format("No such file '%s': %s", filename, exception));
+        }
+        return Optional.empty();
+    }
+
+    /**
      * Read an island from a file within the class resources
      *
      * Useful for tests
@@ -114,6 +132,20 @@ public class InputParser {
      */
     public static Island islandFromResourceFile(String filename) {
         Optional<BufferedReader> readerOptional = readFileFromResources(filename);
+        Optional<Island> islandOptional = InputParser.parse(readerOptional.orElseThrow(() -> new RuntimeException("Cannot load required test resource")));
+        return islandOptional.orElseThrow(() -> new RuntimeException("Cannot parse input file into island"));
+    }
+
+    /**
+     * Read an island from a file within the class resources
+     *
+     * Useful for tests
+     *
+     * @param filename The full filename of the file within resources
+     * @return
+     */
+    public static Island islandFromFile(String filename) {
+        Optional<BufferedReader> readerOptional = readFileFromFileSystem(filename);
         Optional<Island> islandOptional = InputParser.parse(readerOptional.orElseThrow(() -> new RuntimeException("Cannot load required test resource")));
         return islandOptional.orElseThrow(() -> new RuntimeException("Cannot parse input file into island"));
     }


### PR DESCRIPTION
Make it possible to also read from standard input (it was the default up until now).